### PR TITLE
Add external LoadBalancer service support

### DIFF
--- a/charts/anyscale-operator/templates/external_loadbalancer.yaml
+++ b/charts/anyscale-operator/templates/external_loadbalancer.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.externalLoadBalancer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.externalLoadBalancer.serviceName }}
+  namespace: {{ .Values.externalLoadBalancer.ingressNamespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: external-loadbalancer
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.externalLoadBalancer.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  type: LoadBalancer
+  selector:
+    {{- range $key, $value := .Values.externalLoadBalancer.ingressSelector }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  ports:
+    {{- range .Values.externalLoadBalancer.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      protocol: {{ .protocol }}
+      targetPort: {{ .targetPort }}
+    {{- end }}
+{{- end }}

--- a/charts/anyscale-operator/values.yaml
+++ b/charts/anyscale-operator/values.yaml
@@ -251,3 +251,27 @@ gatewayHostname: ""
 rayPriorityClass:
   enabled: false
   priority: 1100
+
+# externalLoadBalancer controls the creation of an external LoadBalancer service for direct ingress access
+externalLoadBalancer:
+  # enabled controls whether to create the external LoadBalancer service
+  enabled: false
+  # serviceName specifies the name of the LoadBalancer service
+  serviceName: "anyscale-external-lb"
+  # ingressNamespace specifies the namespace where the target ingress controller is running
+  ingressNamespace: "ingress-nginx"
+  # ingressSelector specifies the selector to target ingress controller pods
+  # These should be configured to match your specific ingress controller
+  ingressSelector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  # ports specifies the ports to expose on the LoadBalancer
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  # annotations specifies additional annotations for the LoadBalancer service
+  # Configure these based on your cloud provider requirements
+  annotations: {}


### PR DESCRIPTION
## Summary
Add configurable external LoadBalancer service to the Anyscale operator Helm chart to enable direct L4 TCP access to ingress controllers, resolving TLS termination conflicts with Cloudflare tunnels.

## Changes
### New Configuration Options (`values.yaml`)
- `externalLoadBalancer.enabled`: Control whether to deploy the LoadBalancer service
- `externalLoadBalancer.serviceName`: Configurable service name  
- `externalLoadBalancer.ingressNamespace`: Target namespace for ingress controller
- `externalLoadBalancer.ingressSelector`: Selector labels to target specific ingress pods
- `externalLoadBalancer.ports`: Configurable ports (defaults to HTTPS 443)
- `externalLoadBalancer.annotations`: Cloud provider specific annotations

### New Template (`external_loadbalancer.yaml`)
- Conditional LoadBalancer service creation
- Targets existing ingress controller pods via selector
- Supports custom ports and annotations
- Generic defaults with deployment-specific customization

## Features
✅ **Disabled by default** - maintains backward compatibility  
✅ **Generic configuration** - works with any ingress controller  
✅ **Cloud provider agnostic** - customizable annotations  
✅ **Flexible targeting** - configurable selectors and namespaces  

## Problem Solved
Resolves TLS termination conflicts when using Cloudflare tunnels with nginx ingress:
- **Issue**: Double TLS termination (Cloudflare L7 + nginx TLS) causes handshake failures
- **Solution**: Direct L4 TCP LoadBalancer bypass Cloudflare, providing clean external access

## Usage Example
```yaml
externalLoadBalancer:
  enabled: true
  ingressSelector:
    app.kubernetes.io/instance: ingress-nginx-gcp5
  annotations:
    cloud.google.com/load-balancer-type: "External"
```

## Test Plan
- [x] Helm template validation with various configurations
- [x] Generic defaults work with standard nginx ingress
- [x] Conditional deployment (enabled/disabled)
- [ ] Integration testing with actual LoadBalancer deployment
- [ ] Verify external access functionality